### PR TITLE
fix(linux): keep WebView overlay geometry in sync every frame

### DIFF
--- a/webview_all_linux/lib/src/linux_webview_widget.dart
+++ b/webview_all_linux/lib/src/linux_webview_widget.dart
@@ -136,10 +136,8 @@ class _LinuxPlatformWebViewState extends State<_LinuxPlatformWebView>
         return;
       }
       final RenderObject? renderObject = context.findRenderObject();
-      if (renderObject is _LinuxGeometryRenderBox &&
-          !renderObject.isEffectivelyPainted) {
-        _pushRect(Rect.zero, visible: false);
-        return;
+      if (renderObject is _LinuxGeometryRenderBox) {
+        renderObject.syncGeometry();
       }
       _scheduleVisibilityCheck();
     });
@@ -273,10 +271,14 @@ class _LinuxGeometryRenderBox extends RenderProxyBox {
     super.detach();
   }
 
-  @override
-  void paint(PaintingContext context, Offset offset) {
-    super.paint(context, offset);
+  /// Recomputes the on-screen rect of this box and reports it.
+  ///
+  /// Called from [paint] and, while visible, from a per-frame post-frame
+  /// callback so the native overlay keeps tracking the Flutter layout during
+  /// sliver scrolling.
+  void syncGeometry() {
     if (!attached) {
+      _onGeometryChanged(Rect.zero);
       return;
     }
     if (!isEffectivelyPainted) {
@@ -329,5 +331,11 @@ class _LinuxGeometryRenderBox extends RenderProxyBox {
     final Rect rect = Rect.fromPoints(topLeft, bottomRight);
     final Rect viewport = Offset.zero & renderView.size;
     _onGeometryChanged(rect.overlaps(viewport) ? rect : Rect.zero);
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    super.paint(context, offset);
+    syncGeometry();
   }
 }


### PR DESCRIPTION
## Problem

On Linux, the native WebView overlay does not keep up when its widget moves inside a sliver scrollable (e.g. `ListView`): after scrolling, the overlay stays at its previous position and remains visible until a repaint (e.g. mouse hover) brings it back in step.

### Root cause

Linux is the only platform in this package that positions the native view manually. In Android / iOS / macOS..., the position is derived from the render tree every frame by the engine (or the browser).

Two things made the previous implementation miss updates during scroll:

1. Slivers (e.g. `ListView`) wrap children in `RepaintBoundary`s. While scrolling, the viewport only offsets the child's layer — `paint()` on the WebView's render box is **not** invoked — so the paint-time geometry sync never ran.
2. The post-frame callback only handled the *hidden* case (widget scrolled fully out of the viewport → push `Rect.zero`). When the widget stayed visible but merely moved, nothing was pushed, leaving the overlay stale.

## Fix

- Extract the geometry computation of `_LinuxGeometryRenderBox` into a `syncGeometry()` method.
- Call `syncGeometry()` from `paint()` as before, and additionally from a per-frame post-frame callback while the WebView is attached and the application is visible.
- The callback loop self-terminates as soon as the widget is hidden (`Rect.zero`), and `_handleGeometryChanged` deduplicates unchanged rects, so no redundant `setFrame` channel calls are issued.
- Post-frame callbacks do not schedule frames on their own, so there is no cost while the app is idle.

## Why this approach

With a manually positioned overlay, a per-frame post-frame callback is the standard sync pattern: it covers scrolling, animations, window moves, and layout changes alike, and only runs on frames that are already happening. Targeted alternatives (e.g. listening to scroll notifications, or dirty-flagging from `performLayout`) miss non-scroll movement such as `Transform`-based animations and are more complex. The definitive fix (rendering WebKitGTK offscreen into a Flutter `Texture`, like the Windows implementation) is a much larger rewrite.

## Tests

- Existing `webview_all_linux` suite passes (`flutter test`, 39 tests).
- `flutter analyze` reports no issues.
- My widget-level regression test (WebView inside a `ListView`, dragged by 50 px) was used to validate this fix: it **fails on the parent commit** (the reported overlay `y` stays at its stale value) and **passes with this change** (the overlay tracks the scroll).
- Manually verified on Linux desktop (Fedora, Wayland): the overlay tracks scrolling.