### PR TITLE
fix(windows): stop unregistering channel handlers during engine shutdown

### DIFF
--- a/webview_all_windows/windows/src/plugin/windows_host_api.cc
+++ b/webview_all_windows/windows/src/plugin/windows_host_api.cc
@@ -152,7 +152,13 @@ WindowsHostApi::WindowsHostApi(flutter::TextureRegistrar *textures,
 
 WindowsHostApi::~WindowsHostApi() {
   lifetime_state_->owner = nullptr;
-  webview_all_windows::WindowsWebViewHostApi::SetUp(messenger_, nullptr);
+  // Deliberately no SetUp(messenger_, nullptr) here. This destructor only runs
+  // from a plugin registrar destruction callback, which FlutterWindowsEngine
+  // fires from Stop() *after* its own destructor has already nulled the
+  // messenger's engine pointer -- so unregistering would dereference null
+  // inside FlutterDesktopMessengerSetCallback. The dispatcher is torn down
+  // with the engine anyway. See flutter/flutter#118611 and the contract
+  // documented on flutter::MethodChannel::SetMethodCallHandler.
   instances_.clear();
   if (registrar_ != nullptr && window_proc_delegate_id_ >= 0) {
     registrar_->UnregisterTopLevelWindowProcDelegate(window_proc_delegate_id_);


### PR DESCRIPTION
Fixes #37.

## Problem

On Windows the app crashes with an access violation on **every** exit, whether or not a `WebView` was ever created — the plugin registers unconditionally, so its destructor always runs.

```
EXCEPTION 0xc0000005  READ at 0x1e8   thread 0 (platform thread)
flutter_windows.dll+0x1551f  ==  FlutterDesktopMessengerSetCallback+0x26

  rcx (messenger) -> engine_ = 0x0
  rdx (channel)   = "dev.flutter.pigeon.webview_all_windows.WindowsWebViewHostApi.initializeEnvironment"
  r8  (callback)  = 0x0    (NULL => a handler is being UNREGISTERED)
```

### Root cause

`~WindowsHostApi()` unregisters its Pigeon handlers:

```cpp
webview_all_windows::WindowsWebViewHostApi::SetUp(messenger_, nullptr);
```

That destructor only runs from a plugin registrar destruction callback, and `FlutterWindowsEngine` fires those from `Stop()` — which its destructor calls *after* nulling the messenger's engine pointer:

```cpp
FlutterWindowsEngine::~FlutterWindowsEngine() {
  messenger_->SetEngine(nullptr);   // engine pointer nulled FIRST
  Stop();                           // ...then plugin destruction callbacks run
}
```

So `FlutterDesktopMessengerSetCallback` dereferences a null engine to reach the message dispatcher. Its only guard is an `FML_DCHECK`, compiled out in release.

Flutter documents this constraint on `MethodChannel::SetMethodCallHandler`:

> Destroying the MethodChannel will not unregister the handler, so the caller is responsible for unregistering explicitly **if the handler stops being valid before the engine is destroyed.**

and closed [flutter/flutter#118611](https://github.com/flutter/flutter/issues/118611) as working-as-documented, so the fix belongs here. The first-party Pigeon plugins (`url_launcher_windows`, `file_selector_windows`) generate the same `SetUp(messenger, nullptr)` teardown but never call it — their plugin destructors are `= default`.

## Fix

Drop the call, with a comment so it does not come back:

```cpp
WindowsHostApi::~WindowsHostApi() {
  lifetime_state_->owner = nullptr;
  // Deliberately no SetUp(messenger_, nullptr) here. ...
  instances_.clear();
  ...
}
```

Safe unconditionally — the dispatcher is torn down with the engine, and there is no path where the handler outlives it. `messenger_` is still used elsewhere in the file, and `~WebviewBridge` only resets its channel `unique_ptr`s (which does not unregister) and touches the texture registrar, which stays valid throughout `Stop()`.

## Verification

Built `examples/platform` in release against this branch and against `main`, launched the app, let it settle, closed the window with `WM_CLOSE`, and recorded the process exit code.

| entrypoint | `main` | this branch |
|---|---|---|
| `lib/main.dart` (WebView created and navigated) | 3/3 crash — `0xC000041D` | 5/5 clean — exit `0` |
| plain `Scaffold`, no WebView ever constructed | 3/3 crash — `0xC000041D` | 3/3 clean — exit `0` |

`0xC000041D` is `STATUS_FATAL_USER_CALLBACK_EXCEPTION` — the access violation re-raised out of the window procedure. The second row is why this is worth fixing even for apps that only *depend* on the plugin.

The WebView row also exercises `instances_.clear()` with a live instance, so nothing downstream of the removed line regressed.

One note unrelated to this PR: `main` does not currently compile with MSVC 14.51 (VS 2026) — `<experimental/coroutine>` is now a hard `STL1011` error. I built both sides with `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` defined locally so the comparison was apples-to-apples; that workaround is deliberately not part of this PR. Happy to open a separate issue for it.

Windows 11 26200 x64, Flutter 3.47.1 stable (engine `5d53178869`), MSVC 14.51.
